### PR TITLE
Bot no longer processes datafeed when it is initiator:

### DIFF
--- a/apiClientDotNet/Clients/Constants/PodConstants.cs
+++ b/apiClientDotNet/Clients/Constants/PodConstants.cs
@@ -52,6 +52,6 @@ namespace apiClientDotNet.Clients.Constants
         public static String ADMINCREATEUSER =  POD +"/v2/admin/user/create";
         public static String ADMINUPDATEUSER = POD +"/v2/admin/user/{uid}/update";
         public static String ADMINUPDATEAVATAR = POD + "/v1/admin/user/{uid}/avatar/update";
-
+        public static String GETSESSIONUSER = POD + "/v2/sessioninfo";
     }
 }

--- a/apiClientDotNet/Clients/SymBotClient.cs
+++ b/apiClientDotNet/Clients/SymBotClient.cs
@@ -20,6 +20,7 @@ namespace apiClientDotNet
         private UserClient userClient;
         private ConnectionsClient connectionsClient;
         private SignalsClient signalsClient;
+        private UserInfo botUserInfo;
 
         public static SymBotClient initBot(SymConfig config, ISymAuth symBotAuth)
         {
@@ -116,6 +117,14 @@ namespace apiClientDotNet
                 signalsClient = new SignalsClient(this);
             }
             return signalsClient;
+        }
+
+        public UserInfo getBotUserInfo(){
+            if (botUserInfo == null)
+            {
+                botUserInfo = botClient.getUsersClient().getSessionUser();
+            }
+            return botUserInfo;
         }
     }
 }

--- a/apiClientDotNet/Clients/SymOBOClient.cs
+++ b/apiClientDotNet/Clients/SymOBOClient.cs
@@ -32,16 +32,6 @@ namespace apiClientDotNet.Clients
             this.config = config;
         }
 
-       
-        public DatafeedEventsService getDatafeedEventsService()
-        {
-            if (datafeedEventsService == null)
-            {
-                datafeedEventsService = new DatafeedEventsService(this);
-            }
-            return datafeedEventsService;
-        }
-
         public SymConfig getConfig()
         {
             return config;

--- a/apiClientDotNet/Clients/UserClient.cs
+++ b/apiClientDotNet/Clients/UserClient.cs
@@ -216,5 +216,19 @@ namespace apiClientDotNet.Clients
             return result;
         }
 
+        public UserInfo getSessionUser(){
+
+            SymConfig symConfig = botClient.getConfig();
+            UserInfo info = null;
+            RestRequestHandler restRequestHandler = new RestRequestHandler();
+            string url = CommonConstants.HTTPSPREFIX + symConfig.podHost + ":" + symConfig.podPort + PodConstants.GETSESSIONUSER;
+            HttpWebResponse resp = restRequestHandler.executeRequest(null, url, false, WebRequestMethods.Http.Get, symConfig, false);
+            if (resp.StatusCode == HttpStatusCode.OK)
+            {
+                string body = restRequestHandler.ReadResponse(resp);
+                info = JsonConvert.DeserializeObject<UserInfo>(body);
+            }
+            return info;
+        }
     }
 }


### PR DESCRIPTION
SymBotClient:
Added botUserInfo variable to store info about itself

SymOBOClient:
Removed Datafeed functionality as OBO does not use datafeed

PodConstants:
Added new constant for endpoint /v2/sessioninfo

UsersClient:
Added new function to get logged in bot's userinfo.

DatafeedEventsService:
SymOBOClient does not need datafeed
Changed botClient to be defined as a SymBotClient instead of ISymClient
Changed constuctor to only take SymBotClient
Added check to handleEvents for if initiator is self to not process it