### PR TITLE
Fixed RSA Auth:

### DIFF
--- a/apiClientDotNet/Authentication/SymBotRSAAuth.cs
+++ b/apiClientDotNet/Authentication/SymBotRSAAuth.cs
@@ -19,6 +19,7 @@ namespace apiClientDotNet.Authentication
 
         public SymBotRSAAuth(SymConfig config) {
             this.symConfig = config;
+            this.authTokens = new AuthTokens();
         }
         
         public void authenticate() {
@@ -26,7 +27,7 @@ namespace apiClientDotNet.Authentication
             jwt = jwtHandler.generateJWT(symConfig);
             sessionAuthenticate();
             kmAuthenticate();
-
+            symConfig.authTokens = authTokens;
         }
         
         public void sessionAuthenticate() {
@@ -38,9 +39,8 @@ namespace apiClientDotNet.Authentication
             HttpWebResponse resp = restRequestHandler.executeRequest(token, url, true, WebRequestMethods.Http.Post, symConfig, false);
             string body = restRequestHandler.ReadResponse(resp);
             JObject o = JObject.Parse(body);
-            authTokens.sessionToken = (string)o["token"];
-            sessionToken = authTokens.sessionToken;
-            
+            authTokens.sessionToken = (string) o.SelectToken("token");
+            sessionToken = authTokens.sessionToken;    
         }
 
         public void kmAuthenticate() {
@@ -48,11 +48,11 @@ namespace apiClientDotNet.Authentication
             Dictionary<String, String> token = new Dictionary<string, string>();
             token.Add("token", jwt);
             RestRequestHandler restRequestHandler = new RestRequestHandler();
-            string url = "https://" + symConfig.sessionAuthHost + ":" + symConfig.sessionAuthPort + AuthEndpointConstants.RSAKMAUTH;
+            string url = "https://" + symConfig.keyAuthHost + ":" + symConfig.keyAuthPort + AuthEndpointConstants.RSAKMAUTH;
             HttpWebResponse resp = restRequestHandler.executeRequest(token, url, true, WebRequestMethods.Http.Post, symConfig, false);
             string body = restRequestHandler.ReadResponse(resp);
             JObject o = JObject.Parse(body);
-            authTokens.keyManagerToken = (string)o["token"];
+            authTokens.keyManagerToken = (string) o.SelectToken("token");
             kmToken = authTokens.keyManagerToken;
         }
 

--- a/apiClientDotNet/Utils/JWTHandler.cs
+++ b/apiClientDotNet/Utils/JWTHandler.cs
@@ -21,6 +21,7 @@ namespace apiClientDotNet.Utils
 {
     public class JWTHandler
     {
+        /*
         public string generateJWT(SymConfig config)
         {
             string jwt = "";
@@ -33,7 +34,7 @@ namespace apiClientDotNet.Utils
             };
 
             var tokenHandler = new JwtSecurityTokenHandler();
-            var certificate = new X509Certificate2(config.botPrivateKeyPath + config.botPrivateKeyName, "changeit");
+            var certificate = new X509Certificate2(config.botPrivateKeyPath + config.botPrivateKeyName);
             var securityKey = new Microsoft.IdentityModel.Tokens.X509SecurityKey(certificate);
             var credentials = new Microsoft.IdentityModel.Tokens.SigningCredentials(securityKey, SecurityAlgorithms.RsaSha512);
             var header = new JwtHeader(credentials);
@@ -45,8 +46,9 @@ namespace apiClientDotNet.Utils
             return tokenString;
         
         }
+        */
 
-        public string generateJoseJWT(SymConfig config)
+        public string generateJWT(SymConfig config)
         {
             string jwt = "";
 


### PR DESCRIPTION
JWTHandler:

Replaced generateJWT with generateJoseJWT for client parity
generateJWT required a pfx while generateJoseJWT only needs private key

SymBotRSAAuth:

Fixed kmAuthenticate - was using sessionAuthHost instead of keyAuthHost
Correctly parse out session/keyManager token
Set symConfig.authTokens, was not set before. - Used for future calls

RestRequestHandler:

Created workflow for RSAAuth as it did not have a valid path originally
Added sessionAuth RSAAuth to list of calls to use proxy