### PR TITLE
Add entityJSON to form data during post request

### DIFF
--- a/apiClientDotNet/Utils/RestRequestHandler.cs
+++ b/apiClientDotNet/Utils/RestRequestHandler.cs
@@ -149,6 +149,11 @@ namespace apiClientDotNet.Utils
                         formData.Add(byteArrayContent, "attachment", fileName);
                     }
                 }
+                if(message.data != null)
+                {
+                    HttpContent jsonData = new StringContent(message.data);
+                    formData.Add(jsonData, "data", "data");
+                }
                         
                 client.DefaultRequestHeaders.Add("sessionToken", symConfig.authTokens.sessionToken);
                 if(symConfig.authTokens.keyManagerToken != null)


### PR DESCRIPTION
Allow messages which include structured objects by posting json data with the corresponding entity object.

Currently messages which have these entity object result in a bad request when messages are sent.